### PR TITLE
Change regex to support multiple params when including file path params

### DIFF
--- a/src/framework/openapi.spec.loader.ts
+++ b/src/framework/openapi.spec.loader.ts
@@ -106,7 +106,7 @@ export class OpenApiSpecLoader {
     // instead create our own syntax that is compatible with express' pathToRegex
     // /{path}* => /:path*)
     // /{path}(*) => /:path*)
-    const pass1 = part.replace(/\/{([^\*]+)}\({0,1}(\*)\){0,1}/g, '/:$1$2');
+    const pass1 = part.replace(/\/{([^{}]+)}\({0,1}(\*)\){0,1}/g, '/:$1$2');
     // substitute params with express equivalent
     // /path/{id} => /path/:id
     return pass1.replace(/\{([^}]+)}/g, ':$1');

--- a/src/framework/openapi.spec.loader.ts
+++ b/src/framework/openapi.spec.loader.ts
@@ -106,7 +106,7 @@ export class OpenApiSpecLoader {
     // instead create our own syntax that is compatible with express' pathToRegex
     // /{path}* => /:path*)
     // /{path}(*) => /:path*)
-    const pass1 = part.replace(/\/{([^{}]+)}\({0,1}(\*)\){0,1}/g, '/:$1$2');
+    const pass1 = part.replace(/\/{([^}]+)}\({0,1}(\*)\){0,1}/g, '/:$1$2');
     // substitute params with express equivalent
     // /path/{id} => /path/:id
     return pass1.replace(/\{([^}]+)}/g, ':$1');

--- a/test/resources/wildcard.path.params.yaml
+++ b/test/resources/wildcard.path.params.yaml
@@ -56,3 +56,39 @@ paths:
         200:
           description: dummy response
           content: {}
+
+  /d4/{multi}/spaced/{path}(*):
+    get:
+      parameters:
+        - name: multi
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: dummy response
+          content: {}
+
+  /d5/{multi}/{path}(*):
+    get:
+      parameters:
+        - name: multi
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: dummy response
+          content: {}

--- a/test/wildcard.path.params.spec.ts
+++ b/test/wildcard.path.params.spec.ts
@@ -34,6 +34,16 @@ describe('wildcard path params', () => {
             res.json({
               success: true,
             }),
+          )
+          .get(`${app.basePath}/d4/:multi/spaced/:path(*)`, (req, res) =>
+            res.json({
+              ...req.params,
+            }),
+          )
+          .get(`${app.basePath}/d5/:multi/:path(*)`, (req, res) =>
+            res.json({
+              ...req.params,
+            }),
           );
       },
     );
@@ -82,5 +92,23 @@ describe('wildcard path params', () => {
       .expect(200)
       .then((r) => {
         expect(r.body.success).to.be.true;
+      }));
+
+  it('should return 200 when wildcard path includes all required params and multiple path params', async () =>
+    request(app)
+      .get(`${app.basePath}/d4/one/spaced/two/three/four`)
+      .expect(200)
+      .then((r) => {
+        expect(r.body.multi).to.equal('one');
+        expect(r.body.path).to.equal('two/three/four');
+      }));
+
+  it('should return 200 when wildcard path includes all required params and multiple path params', async () =>
+    request(app)
+      .get(`${app.basePath}/d5/one/two/three/four`)
+      .expect(200)
+      .then((r) => {
+        expect(r.body.multi).to.equal('one');
+        expect(r.body.path).to.equal('two/three/four');
       }));
 });


### PR DESCRIPTION
## Summary
Changing the regex that replaces the path param to support `RFC-6570` (`/{file}*`) when there are multiple params on the endpoint path.